### PR TITLE
Forward compatibility with react/event-loop 1.0 and 0.5 while still supporting 0.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require": {
         "voryx/thruway-common": "^1.0",
-        "react/event-loop": "^0.4.3",
+        "react/event-loop": "^1.0 || ^0.5 || ^0.4.3",
         "evenement/evenement": "^3.0 || ^2.0",
         "psr/log": "^1.0",
         "react/promise-timer": "^1.2.1"

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -76,7 +76,7 @@ class Connection implements EventEmitterInterface
      */
     public function doEvents($timer = 1)
     {
-        $loop = $this->getClient()->getLoop();
+        /*$loop = $this->getClient()->getLoop();
 
         $looping = true;
         $loop->addTimer($timer, function () use (&$looping) {
@@ -86,7 +86,7 @@ class Connection implements EventEmitterInterface
         while ($looping) {
             usleep(1000);
             $loop->tick();
-        }
+        }*/
     }
 
     /**


### PR DESCRIPTION
Make some changes in [`src/Connection.php`](https://github.com/thruway/client/compare/master...WyriHaximus-labs:react-eventloop-1.0-0.5-0.4#diff-605b1b829c7a2ab3747175bc34ff7b39) but unsure what to change it to as we removed the `Loop::tick` method and this method relies on it.