### PR TITLE
Allow the default client role instances to be overridden

### DIFF
--- a/src/Peer/Client.php
+++ b/src/Peer/Client.php
@@ -260,10 +260,9 @@ class Client implements EventEmitterInterface, ClientInterface
      */
     public function startSession(ClientSession $session)
     {
-        $this->addRole(new Callee())
-            ->addRole(new Caller())
-            ->addRole(new Publisher())
-            ->addRole(new Subscriber());
+        foreach ($this->getDefaultRoles() as $role) {
+            $this->addRole($role);
+        }
 
         $details = (object)[
             'roles' => $this->getRoleInfoObject()
@@ -627,5 +626,18 @@ class Client implements EventEmitterInterface, ClientInterface
     public function setLoop(LoopInterface $loop)
     {
         $this->loop = $loop;
+    }
+
+    /**
+     * @return array|\Thruway\Role\AbstractRole[]
+     */
+    protected function getDefaultRoles()
+    {
+        return [
+            new Callee(),
+            new Caller(),
+            new Publisher(),
+            new Subscriber(),
+        ];
     }
 }

--- a/src/Role/Callee.php
+++ b/src/Role/Callee.php
@@ -32,13 +32,13 @@ class Callee extends AbstractRole
     /**
      * @var array
      */
-    private $registrations;
+    protected $registrations;
 
     /**
      * @var array
      */
-    private $invocationCanceller = [];
-    
+    protected $invocationCanceller = [];
+
     /**
      * Constructor
      */
@@ -383,7 +383,7 @@ class Callee extends AbstractRole
             return false;
         }
     }
-    
+
     /**
      * process register
      *
@@ -499,4 +499,4 @@ class Callee extends AbstractRole
         // not be associative (e.g. the keys array looked like {0:0, 1:1...}).
         return array_keys($keys) === $keys;
     }
-} 
+}

--- a/src/Role/Publisher.php
+++ b/src/Role/Publisher.php
@@ -22,7 +22,7 @@ class Publisher extends AbstractRole
     /**
      * @var array
      */
-    private $publishRequests;
+    protected $publishRequests;
 
     /**
      * Constructor

--- a/src/Role/Subscriber.php
+++ b/src/Role/Subscriber.php
@@ -25,7 +25,7 @@ class Subscriber extends AbstractRole
     /**
      * @var array
      */
-    private $subscriptions;
+    protected $subscriptions;
 
     /**
      * Constructor
@@ -221,4 +221,4 @@ class Subscriber extends AbstractRole
 
         return $deferred->promise();
     }
-} 
+}


### PR DESCRIPTION
I've run into some issues where code could not be extended or modified. I have a use case for extending the `Subscriber`, but there's no way to override the instance in the client (`$roles` is private and there is no way to remove roles from the outside). This non-breaking change will allow the default role instances to be overridden.

Thanks for your work, by the way!