### PR TITLE
Widen psr/log version targeting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "voryx/thruway-common": "^1.0",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4.3",
         "evenement/evenement": "^3.0 || ^2.0",
-        "psr/log": "^1.0",
+        "psr/log": "^3 || ^2 || ^1",
         "react/promise-timer": "^1.2.1"
     },
     "require-dev": {


### PR DESCRIPTION
Since this package is only a consumer on the psr/log package there is no need to limit it only to the v1 version. v2 and v3 are identical feature wise, but they have added language features such as return type hints.