### PR TITLE
Fix ConsoleLogger compatibility with PHP 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 vendor
 .idea
+.phpunit.result.cache
 composer.lock
 nbproject

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "react/promise-timer": "^1.2.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.5.4",
+        "phpunit/phpunit": "^8.5",
         "thruway/pawl-transport": "dev-master"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
         convertWarningsToExceptions="true"
         processIsolation="false"
         stopOnFailure="false"
-        syntaxCheck="false"
         bootstrap="test/bootstrap.php">
     <testsuites>
         <testsuite name="Thruway Client Tests">

--- a/src/Logging/ConsoleLogger.php
+++ b/src/Logging/ConsoleLogger.php
@@ -4,24 +4,51 @@ namespace Thruway\Logging;
 
 use Psr\Log\AbstractLogger;
 
-/**
- * Class ConsoleLogger
- *
- * @package Thruway
- */
-class ConsoleLogger extends AbstractLogger
-{
+if (\PHP_VERSION_ID >= 80000) {
     /**
-     * Logs with an arbitrary level.
+     * Class ConsoleLogger
      *
-     * @param mixed $level
-     * @param string $message
-     * @param array $context
-     * @return null
+     * @package Thruway
      */
-    public function log($level, $message, array $context = [])
+    class ConsoleLogger extends AbstractLogger
     {
-        $now = date("Y-m-d\TH:i:s") . substr((string)microtime(), 1, 8);
-        echo $now . " " . str_pad($level, 10, " ") . " " . $message . "\n";
+        /**
+         * Logs with an arbitrary level.
+         *
+         * @param mixed $level
+         * @param string $message
+         * @param array $context
+         * @return null
+         */
+
+        public function log($level, string|\Stringable $message, array $context = []): void
+        {
+            $now = date("Y-m-d\TH:i:s") . substr((string)microtime(), 1, 8);
+            echo $now . " " . str_pad($level, 10, " ") . " " . $message . "\n";
+        }
+    }
+} else {
+
+    /**
+     * Class ConsoleLogger
+     *
+     * @package Thruway
+     */
+    class ConsoleLogger extends AbstractLogger
+    {
+        /**
+         * Logs with an arbitrary level.
+         *
+         * @param mixed $level
+         * @param string $message
+         * @param array $context
+         * @return null
+         */
+
+        public function log($level, $message, array $context = [])
+        {
+            $now = date("Y-m-d\TH:i:s") . substr((string)microtime(), 1, 8);
+            echo $now . " " . str_pad($level, 10, " ") . " " . $message . "\n";
+        }
     }
 }

--- a/test/Logging/ConsoleLoggerTest.php
+++ b/test/Logging/ConsoleLoggerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Logging;
+
+use PHPUnit\Framework\TestCase;
+use Thruway\Logging\ConsoleLogger;
+
+class ConsoleLoggerTest extends TestCase
+{
+    /**
+     * @dataProvider logLevels
+     */
+    public function testLog($level)
+    {
+        $logger = new ConsoleLogger();
+
+        $expectedOutput = "\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{7}\s+$level\s+Hello World";
+        $this->expectOutputRegex("/^$expectedOutput$/");
+
+        $logger->$level('Hello World');
+    }
+
+    public function logLevels()
+    {
+        return [
+            ['emergency'],
+            ['alert'],
+            ['critical'],
+            ['error'],
+            ['warning'],
+            ['notice'],
+            ['info'],
+            ['debug'],
+        ];
+    }
+}

--- a/test/Peer/ClientTest.php
+++ b/test/Peer/ClientTest.php
@@ -2,20 +2,20 @@
 
 namespace Thruway\Peer;
 
+use PHPUnit\Framework\TestCase;
 use React\EventLoop\Factory;
 use Thruway\Transport\ClientTestTransportProvider;
 
-class ClientTest extends \PHPUnit_Framework_TestCase
+class ClientTest extends TestCase
 {
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage You must add exactly one transport provider prior to starting
-     */
     public function testClientMustHaveTransportProvider()
     {
         $loop = Factory::create();
 
         $client = new Client('some.realm', $loop);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('You must add exactly one transport provider prior to starting');
 
         $client->start();
     }
@@ -25,5 +25,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $client = new Client('some.realm', Factory::create());
 
         $client->addTransportProvider(new ClientTestTransportProvider());
+
+        $this->assertTrue(true, "No error occured.");
     }
 }


### PR DESCRIPTION
The PR #11 allow the `psr/log` v3 usage.
But this release has strict typing on `LoggerInterface` methods.

So it breaks the library compatibility because of inheritance incompatibility:

`Declaration of Thruway\Logging\ConsoleLogger::log($level, $message, array $context = []) must be compatible with Psr\Log\AbstractLogger::log($level, Stringable|string $message, array $context = []): void in /thruway/vendor/thruway/client/src/Logging/ConsoleLogger.php on line 22`

This PR fix that issue.