### PR TITLE
Fixed doc comments of logger, and added type hints where applicable.

### DIFF
--- a/src/Logging/ConsoleLogger.php
+++ b/src/Logging/ConsoleLogger.php
@@ -17,7 +17,7 @@ class ConsoleLogger extends AbstractLogger
      * @param mixed $level
      * @param string $message
      * @param array $context
-     * @return null
+     * @return void
      */
     public function log($level, $message, array $context = []) : void
     {

--- a/src/Logging/Logger.php
+++ b/src/Logging/Logger.php
@@ -15,20 +15,21 @@ class Logger
 
     /**
      * @param LoggerInterface $logger
+     * @return void
      */
-    public static function set(LoggerInterface $logger)
+    public static function set(LoggerInterface $logger): void
     {
         static::$logger = $logger;
     }
 
     /**
-     * @param null $object
-     * @param $level
-     * @param $message
+     * @param null|object $object
+     * @param mixed $level
+     * @param mixed $message
      * @param array $context
-     * @return null
+     * @return void
      */
-    public static function log($object, $level, $message, $context = [])
+    public static function log($object, $level, $message, array $context = []): void
     {
         if (is_object($object)) {
             $className = get_class($object);
@@ -44,96 +45,96 @@ class Logger
     }
 
     /**
-     * @param null $object
-     * @param null $object
-     * @param $message
+     * @param null|object $object
+     * @param mixed $message
      * @param array $context
-     * @return null
+     * @return void
      */
-    public static function alert($object, $message, $context = [])
+    public static function alert($object, $message, array $context = []): void
     {
         static::log($object, LogLevel::ALERT, $message, $context);
     }
 
     /**
-     * @param null $object
-     * @param $message
+     * @param null|object $object
+     * @param mixed $message
      * @param array $context
-     * @return null
+     * @return void
      */
-    public static function critical($object, $message, $context = [])
+    public static function critical($object, $message, array $context = []): void
     {
         static::log($object, LogLevel::CRITICAL, $message, $context);
     }
 
     /**
-     * @param null $object
-     * @param $message
+     * @param null|object $object
+     * @param mixed $message
      * @param array $context
-     * @return null
+     * @return void
      */
-    public static function debug($object, $message, $context = [])
+    public static function debug($object, $message, array $context = []): void
     {
         static::log($object, LogLevel::DEBUG, $message, $context);
     }
 
     /**
-     * @param null $object
-     * @param $message
+     * @param null|object $object
+     * @param mixed $message
      * @param array $context
-     * @return null
+     * @return void
      */
-    public static function emergency($object, $message, $context = [])
+    public static function emergency($object, $message, array $context = []): void
     {
         static::log($object, LogLevel::EMERGENCY, $message, $context);
     }
 
     /**
-     * @param null $object
-     * @param $message
+     * @param null|object $object
+     * @param mixed $message
      * @param array $context
-     * @return null
+     * @return void
      */
-    public static function error($object, $message, $context = [])
+    public static function error($object, $message, array $context = []): void
     {
         static::log($object, LogLevel::ERROR, $message, $context);
     }
 
     /**
-     * @param null $object
-     * @param $message
+     * @param null|object $object
+     * @param mixed $message
      * @param array $context
-     * @return null
+     * @return void
      */
-    public static function info($object, $message, $context = [])
+    public static function info($object, $message, array $context = []): void
     {
         static::log($object, LogLevel::INFO, $message, $context);
     }
 
     /**
-     * @param null $object
-     * @param $message
+     * @param null|object $object
+     * @param mixed $message
      * @param array $context
-     * @return null
+     * @return void
      */
-    public static function notice($object, $message, $context = [])
+    public static function notice($object, $message, array $context = []): void
     {
         static::log($object, LogLevel::NOTICE, $message, $context);
     }
 
     /**
-     * @param $message
+     * @param null|object $object
+     * @param mixed $message
      * @param array $context
-     * @return null
+     * @return void
      */
-    public static function warning($object, $message, $context = [])
+    public static function warning($object, $message, array $context = []): void
     {
         static::log($object, LogLevel::WARNING, $message, $context);
     }
 
     /**
      * Protected constructor to prevent creating a new instance of the
-     * *Singleton* via the `new` operator from outside of this class.
+     * *Singleton* via the `new` operator from outside this class.
      */
     protected function __construct()
     {


### PR DESCRIPTION
On a half related note... I see the latest commit also added PHP be ">7.1"... Shouldn't this be ">=7.1"? Or If the intention is "at least 7.2", maybe make that ">=7.2"? Also, probably good to update the readme too.

This PR only updates the type hints to PHP 7.1 levels, not 7.2 levels. In particular, 7.2 introduces "object" as a valid type hint, but I have not added it, in case the intent was actually ">=7.1".