### PR TITLE
Fixed required PHP version, to be a minimum of 7.1, not 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     },
     "require": {
-        "php": ">7.1",
+        "php": ">=7.1",
         "voryx/thruway-common": "^1.0",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4.3",
         "evenement/evenement": "^3.0 || ^2.0",


### PR DESCRIPTION
As mentioned in #16, I'm pretty sure ">7.1" is a mistake, and it should be ">=7.1" instead.

Here it is in a separate PR.