### PR TITLE
Emit the close event even when the reason is connection failure.

### DIFF
--- a/src/Peer/Client.php
+++ b/src/Peer/Client.php
@@ -451,8 +451,8 @@ class Client implements EventEmitterInterface, ClientInterface
             $this->onSessionEnd($this->session);
             $this->session->onClose();
             $this->session = null;
-            $this->emit('close', [$reason]);
         }
+        $this->emit('close', [$reason]);
 
         $this->roles      = [];
         $this->callee     = null;


### PR DESCRIPTION
Right now, if there is a connection failure, there is no way to handle it in any custom way. You only get the log in the rejection promise and that's it.

This PR changes it so that the close event is emitted even on connection failures, with $reason = "unreachable".